### PR TITLE
Fix unicode strings conversion to str

### DIFF
--- a/fedwatch.py
+++ b/fedwatch.py
@@ -88,7 +88,12 @@ class FedWatch(object):
                     continue
 
                 procarg=[fpath]
-                procarg.extend([str(parg) for parg in pargs])
+                for parg in pargs:
+                    if isinstance(parg, unicode):
+                        procarg.append(parg.encode('utf-8'))
+                    else:
+                        procarg.append(str(parg))
+
                 st = os.stat(fpath)
                 proc_owner = os.getuid()
                 mode = st.st_mode


### PR DESCRIPTION
We used to do a simple str() type conversion before to convert numbers to
strings when running scripts. However this didn't account for trying to run
script with unicode strings. So it could have happened that a script was
supposed to be run with unicode string which couldn't be converted into ascii
str. Instead we hardcode this conversion into utf-8 encoding

Fixes #9